### PR TITLE
Update samples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -356,6 +356,4 @@ MigrationBackup/
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
 
-# Voxel Tycoon libs
-/Libs/UnityEngine.CoreModule.dll
-/Libs/Assembly-CSharp.dll
+VoxelTycoonInstallationDirectory.txt

--- a/CustomRulesExampleMod/CustomRulesExampleMod.csproj
+++ b/CustomRulesExampleMod/CustomRulesExampleMod.csproj
@@ -15,9 +15,11 @@
     <ItemGroup>
       <Reference Include="UnityEngine.CoreModule">
         <HintPath>$(VoxelTycoonManagedLibraryDirectory)\UnityEngine.CoreModule.dll</HintPath>
+        <Private>false</Private>
       </Reference>
       <Reference Include="VoxelTycoon">
         <HintPath>$(VoxelTycoonManagedLibraryDirectory)\VoxelTycoon.dll</HintPath>
+        <Private>false</Private>
       </Reference>
     </ItemGroup>
 

--- a/CustomRulesExampleMod/CustomRulesExampleMod.csproj
+++ b/CustomRulesExampleMod/CustomRulesExampleMod.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>netstandard2.1</TargetFramework>
+        <LangVersion>10</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/CustomRulesExampleMod/CustomRulesExampleMod.csproj
+++ b/CustomRulesExampleMod/CustomRulesExampleMod.csproj
@@ -14,10 +14,10 @@
 
     <ItemGroup>
       <Reference Include="UnityEngine.CoreModule">
-        <HintPath>..\Libs\UnityEngine.CoreModule.dll</HintPath>
+        <HintPath>$(VoxelTycoonManagedLibraryDirectory)\UnityEngine.CoreModule.dll</HintPath>
       </Reference>
       <Reference Include="VoxelTycoon">
-        <HintPath>..\Libs\VoxelTycoon.dll</HintPath>
+        <HintPath>$(VoxelTycoonManagedLibraryDirectory)\VoxelTycoon.dll</HintPath>
       </Reference>
     </ItemGroup>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Project>
+  <PropertyGroup Label="VoxelTycoon">
+    <VoxelTycoonInstallationDirectoryOverrideFilePath>$([MSBuild]::GetPathOfFileAbove('VoxelTycoonInstallationDirectory.txt', '$(MSBuildProjectDirectory)'))</VoxelTycoonInstallationDirectoryOverrideFilePath>
+    <VoxelTycoonInstallationDirectory
+      Condition="Exists('$(VoxelTycoonInstallationDirectoryOverrideFilePath)')"
+    >$([System.IO.File]::ReadAllText('$(VoxelTycoonInstallationDirectoryOverrideFilePath)').Trim())</VoxelTycoonInstallationDirectory>
+    <VoxelTycoonInstallationDirectory Condition="!Exists('$(VoxelTycoonInstallationDirectoryOverrideFilePath)')">$([System.IO.Path]::GetFullPath('$(Registry:HKEY_CURRENT_USER\Software\Valve\Steam@SteamPath)\steamapps\common\VoxelTycoon'))</VoxelTycoonInstallationDirectory>
+    <VoxelTycoonManagedLibraryDirectory>$(VoxelTycoonInstallationDirectory)\VoxelTycoon_Data\Managed</VoxelTycoonManagedLibraryDirectory>
+  </PropertyGroup>
+</Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Project>
+  <Target 
+    Name="ErrorMissingVoxelTycoonInstallationDirectory" 
+    BeforeTargets="ResolveReferences"
+    Condition="!Exists('$(VoxelTycoonInstallationDirectory)')"
+  >
+    <Error
+      Condition="'$(VoxelTycoonInstallationDirectoryOverrideFilePath)' != '' and Exists('$(VoxelTycoonInstallationDirectoryOverrideFilePath)')"
+      File="$(VoxelTycoonInstallationDirectoryOverrideFilePath)"
+      Text="Specified VoxelTycoon directory path '$(VoxelTycoonInstallationDirectory)' does not exist."
+    />
+    <Error
+      Condition="'$(VoxelTycoonInstallationDirectoryOverrideFilePath)' == '' or !Exists('$(VoxelTycoonInstallationDirectoryOverrideFilePath)')"
+      Text="VoxelTycoon could not be detected automatically. Provide the VoxelTycoon directory path in a 'VoxelTycoonInstallationDirectory.txt' file."
+    />
+  </Target>
+</Project>

--- a/HelloVoxelWorldMod/HelloVoxelWorldMod.csproj
+++ b/HelloVoxelWorldMod/HelloVoxelWorldMod.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/HelloVoxelWorldMod/HelloVoxelWorldMod.csproj
+++ b/HelloVoxelWorldMod/HelloVoxelWorldMod.csproj
@@ -10,11 +10,11 @@
 
   <ItemGroup>
     <Reference Include="VoxelTycoon">
-      <HintPath>..\Libs\VoxelTycoon.dll</HintPath>
+      <HintPath>$(VoxelTycoonManagedLibraryDirectory)\VoxelTycoon.dll</HintPath>
       <Private>false</Private>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\Libs\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>$(VoxelTycoonManagedLibraryDirectory)\UnityEngine.CoreModule.dll</HintPath>
       <Private>false</Private>
     </Reference>
   </ItemGroup>

--- a/HelloVoxelWorldMod/HelloVoxelWorldMod.csproj
+++ b/HelloVoxelWorldMod/HelloVoxelWorldMod.csproj
@@ -19,8 +19,10 @@
     </Reference>
   </ItemGroup>
 
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="set target=E:\dev\voxeltycoon\_Builds\local\windows\Content\vt_samples&#xD;&#xA;mkdir %25target%25&#xD;&#xA;copy $(TargetPath) %25target%25&#xD;&#xA;@echo { &quot;Title&quot;: &quot;Voxel Tycoon Moding Samples&quot;, &quot;Description&quot;: &quot;&quot; }&gt; %25target%25\pack.json" />
-  </Target>
+  <ItemGroup>
+    <None Update="mod.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
 </Project>

--- a/HelloVoxelWorldMod/HelloVoxelWorldMod.csproj
+++ b/HelloVoxelWorldMod/HelloVoxelWorldMod.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Assembly-CSharp">
-      <HintPath>..\Libs\Assembly-CSharp.dll</HintPath>
+    <Reference Include="VoxelTycoon">
+      <HintPath>..\Libs\VoxelTycoon.dll</HintPath>
       <Private>false</Private>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">

--- a/HelloVoxelWorldMod/mod.json
+++ b/HelloVoxelWorldMod/mod.json
@@ -1,0 +1,4 @@
+{
+  "Title": "Voxel Tycoon Moding Samples",
+  "Description": ""
+}

--- a/InfiniteResourcesMod/InfiniteResourcesMod.csproj
+++ b/InfiniteResourcesMod/InfiniteResourcesMod.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/InfiniteResourcesMod/InfiniteResourcesMod.csproj
+++ b/InfiniteResourcesMod/InfiniteResourcesMod.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Assembly-CSharp">
-      <HintPath>..\Libs\Assembly-CSharp.dll</HintPath>
+    <Reference Include="VoxelTycoon">
+      <HintPath>..\Libs\VoxelTycoon.dll</HintPath>
       <Private>false</Private>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">

--- a/InfiniteResourcesMod/InfiniteResourcesMod.csproj
+++ b/InfiniteResourcesMod/InfiniteResourcesMod.csproj
@@ -6,11 +6,11 @@
 
   <ItemGroup>
     <Reference Include="VoxelTycoon">
-      <HintPath>..\Libs\VoxelTycoon.dll</HintPath>
+      <HintPath>$(VoxelTycoonManagedLibraryDirectory)\VoxelTycoon.dll</HintPath>
       <Private>false</Private>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\Libs\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>$(VoxelTycoonManagedLibraryDirectory)\UnityEngine.CoreModule.dll</HintPath>
       <Private>false</Private>
     </Reference>
   </ItemGroup>

--- a/Mods.sln
+++ b/Mods.sln
@@ -3,6 +3,16 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.32014.148
 MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "(Repository Root)", "(Repository Root)", "{8D331F94-F604-410F-ADED-0715964DCE01}"
+	ProjectSection(SolutionItems) = preProject
+		.gitignore = .gitignore
+		Directory.Build.props = Directory.Build.props
+		Directory.Build.targets = Directory.Build.targets
+		LICENSE = LICENSE
+		README.md = README.md
+		VoxelTycoonInstallationDirectory.txt = VoxelTycoonInstallationDirectory.txt
+	EndProjectSection
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OldSchoolStyleMod", "OldSchoolStyleMod\OldSchoolStyleMod.csproj", "{4B03A377-4852-4113-AE6F-E68A6087885A}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HelloVoxelWorldMod", "HelloVoxelWorldMod\HelloVoxelWorldMod.csproj", "{17110021-9D11-4D8E-9F72-85378660BDA3}"

--- a/OldSchoolStyleMod/OldSchoolStyleMod.csproj
+++ b/OldSchoolStyleMod/OldSchoolStyleMod.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/OldSchoolStyleMod/OldSchoolStyleMod.csproj
+++ b/OldSchoolStyleMod/OldSchoolStyleMod.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Assembly-CSharp">
-      <HintPath>..\Libs\Assembly-CSharp.dll</HintPath>
+    <Reference Include="VoxelTycoon">
+      <HintPath>..\Libs\VoxelTycoon.dll</HintPath>
       <Private>false</Private>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">

--- a/OldSchoolStyleMod/OldSchoolStyleMod.csproj
+++ b/OldSchoolStyleMod/OldSchoolStyleMod.csproj
@@ -6,11 +6,11 @@
 
   <ItemGroup>
     <Reference Include="VoxelTycoon">
-      <HintPath>..\Libs\VoxelTycoon.dll</HintPath>
+      <HintPath>$(VoxelTycoonManagedLibraryDirectory)\VoxelTycoon.dll</HintPath>
       <Private>false</Private>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\Libs\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>$(VoxelTycoonManagedLibraryDirectory)\UnityEngine.CoreModule.dll</HintPath>
       <Private>false</Private>
     </Reference>
   </ItemGroup>

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a repository containing source code for mods and samples made by Voxel T
 
 Modding documentation: [**docs.voxeltycoon.xyz**](https://docs.voxeltycoon.xyz)
 
-> `VoxelTycoon.dll` and `UnityEngine.CoreModule.dll` are not included in the repository. They can be found in the `<game_directory>/VoxelTycoon_Data/Managed` folder and should be manually put into the `Lib` folder before building projects.
+> `VoxelTycoon.dll` and `UnityEngine.CoreModule.dll` are not included in the repository. Their actual location is automatically detected using the `Directory.Build.props` file if VoxelTycoon is installed in the default SteamLibrary location. If VoxelTycoon is installed at a different location, place a `VoxelTycoonInstallationDirectory.txt` in the repository directory and write the path to directory containing the `VoxelTycoon.exe` executable. E.g. `C:\Program Files (x86)\Steam\steamapps\common\VoxelTycoon`
 
 ## Hello Voxel World
 

--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ Shows how to implement custom settings for your mod, so the player can tune them
 
 ## Infinite Resources
 
-![](https://github.com/voxeltycoon/mods/blob/master/InfiniteResourcesMod/preview.png?raw=true)
+![InfiniteResourcesMod](InfiniteResourcesMod/preview.png)
 
 Makes resource deposits never deplete.
 
 ## Old School Style
 
-![](https://github.com/voxeltycoon/mods/blob/master/OldSchoolStyleMod/preview.png?raw=true)
+![OldSchoolStyleMod](OldSchoolStyleMod/preview.png)
 
 Make the game older by 20 years thanks to nostalgic old school styled vehicles movement.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a repository containing source code for mods and samples made by Voxel T
 
 Modding documentation: [**docs.voxeltycoon.xyz**](https://docs.voxeltycoon.xyz)
 
-> `Assembly-CSharp.dll` and `UnityEngine.CoreModule.dll` are not included in the repository. They can be found in the `<game_directory>/VoxelTycoon_Data/Managed` folder and should be manually put into the `Lib` folder before building projects.
+> `VoxelTycoon.dll` and `UnityEngine.CoreModule.dll` are not included in the repository. They can be found in the `<game_directory>/VoxelTycoon_Data/Managed` folder and should be manually put into the `Lib` folder before building projects.
 
 ## Hello Voxel World
 

--- a/SettingsExampleMod/SettingsExampleMod.csproj
+++ b/SettingsExampleMod/SettingsExampleMod.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SettingsExampleMod/SettingsExampleMod.csproj
+++ b/SettingsExampleMod/SettingsExampleMod.csproj
@@ -6,10 +6,10 @@
 
   <ItemGroup>
     <Reference Include="VoxelTycoon">
-      <HintPath>..\Libs\VoxelTycoon.dll</HintPath>
+      <HintPath>$(VoxelTycoonManagedLibraryDirectory)\VoxelTycoon.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\Libs\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>$(VoxelTycoonManagedLibraryDirectory)\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
   </ItemGroup>
 

--- a/SettingsExampleMod/SettingsExampleMod.csproj
+++ b/SettingsExampleMod/SettingsExampleMod.csproj
@@ -7,9 +7,11 @@
   <ItemGroup>
     <Reference Include="VoxelTycoon">
       <HintPath>$(VoxelTycoonManagedLibraryDirectory)\VoxelTycoon.dll</HintPath>
+      <Private>false</Private>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
       <HintPath>$(VoxelTycoonManagedLibraryDirectory)\UnityEngine.CoreModule.dll</HintPath>
+      <Private>false</Private>
     </Reference>
   </ItemGroup>
 

--- a/SettingsExampleMod/SettingsExampleMod.csproj
+++ b/SettingsExampleMod/SettingsExampleMod.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Assembly-CSharp">
-      <HintPath>..\Libs\Assembly-CSharp.dll</HintPath>
+    <Reference Include="VoxelTycoon">
+      <HintPath>..\Libs\VoxelTycoon.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
       <HintPath>..\Libs\UnityEngine.CoreModule.dll</HintPath>


### PR DESCRIPTION
## Minor changes/fixes
- Change references from `Assembly-CSharp` to `VoxelTycoon`
- Update Target framework for mods to `netstandard2.1`
- Ensure that `<Private>false</Private>` is set for all assembly reference across all projects
- `HelloVoxelWorldMod`
   - Replace Post build event with `mod.json` file included in project and copied to output directory to align with other sample projects

## Auto-detect logic for VoxelTycoon installation directory
This PR suggest to replace the manual copying of dlls into the `Libs` folder by creating logic that will determine the location of the VoxelTycoon installation directory automatically at build time.
Suggested logic specified in `Directory.Build.props`:
1. Search for a file `VoxelTycoonInstallationDirectory.txt` in or above the project directory and read path from it
2. Read the registry key `HKCU\Software\Valve\Steam@SteamPath` for the installation directory of Steam and append `\steamapps\common\VoxelTycoon` to it.

An additional validation target is added to `Directory.Build.targets` which will provide an error message if VoxelTycoon directory is not automatically detected or if override path in `VoxelTycoonInstallationDirectory.txt` does not exist.